### PR TITLE
Reformat file path if using  Windows

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,7 +32,8 @@ export default {
         // establish const vars
         const helpers = require('atom-linter');
         const path = require('path');
-        const file = activeEditor.getPath();
+        var activeFilePath = activeEditor.getPath();
+        const file = process.platform === 'win32' ? activeFilePath.replace(/\\/g, '/') : activeFilePath;
         const dir = path.dirname(file);
         // regexps for matching on output
         const regex_syntax = /Error.*\/(.*):\sAt\s(\d+):(\d+):\s(.*)/;
@@ -54,6 +55,9 @@ export default {
           var toReturn = [];
           output.split(/\r?\n/).forEach(function (line) {
             // matchers for output parsing and capturing
+            if (process.platform === 'win32' ) {
+              line = line.replace(/\\/g, '/');
+            }
             const matches_syntax = regex_syntax.exec(line);
             const matches_file = correct_file.exec(line);
             const matches_dir = dir_error.exec(line);


### PR DESCRIPTION
On Windows, the file path is not properly formatted before usage. Solution was either to use a double backslash or convert the file path backslash to forward slash. This PR opts for the latter.  Tested against:
``
Platform: win32
Atom Version: 1.17.2
Linter Version: 2.1.4
All Linter Providers: 
  - JSON Lint
  - Terraform
  - TSLint
  - Unknown
Matching Linter Providers: 
  - Terraform
Disabled Linter Providers; 
Current File scopes: 
  - *
  - source.terraform
  - meta.section
  - keyword.operator.heredoc
  - string.interpolated